### PR TITLE
fix: correct minor typos in English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ English | [简体中文](./README.zh_CN.md)
 
 Hippy is a cross-platform development framework, aiming to help developers write once, run on three platforms(iOS, Android and Web). Hippy is quite friendly to web developers, especially who are familiar with React or Vue. With Hippy, developers are able to create the cross platform app easily.
 
-Hippy is now applied in 18 [Tencent](http://www.tencent.com/) apps concerning tens of billions of ordinary users.
+Hippy is now applied in 18 [Tencent](http://www.tencent.com/) apps reaching hundreds of millions of ordinary users.
 
 ## Advantages
 


### PR DESCRIPTION
The Chinese README states "每日触达数亿用户", which in English translates to "reaches hundreds of millions of users daily", but the English README states it reaches "tens of billions" of users (there are only 7 billion people on the planet). This should read "hundreds of millions".

I also changed "concerning" to "reaching" as it's a more natural word for this context.