### PR TITLE
fix(debug-server): fix yargs usage error

### DIFF
--- a/packages/hippy-debug-server/index.js
+++ b/packages/hippy-debug-server/index.js
@@ -3,7 +3,7 @@
 const yargs       = require('yargs');
 const startServer = require('./server');
 
-const { argv } = yargs()
+const { argv } = yargs
   .alias('v', 'version')
   .describe('v', 'show version information')
   .alias('h', 'help')


### PR DESCRIPTION
It can't parse arguments before this repair, only default option works.

SEE: https://github.com/yargs/yargs/blob/master/docs/api.md#choiceskey-choices

Before submitting a new pull request, please make sure:

- [x] Test cases have been added/updated for the code you will submit.
- [x] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
