### PR TITLE
fix(react-demo):  android  invalid header error

### DIFF
--- a/examples/hippy-react-demo/src/components/WebView/index.jsx
+++ b/examples/hippy-react-demo/src/components/WebView/index.jsx
@@ -32,8 +32,8 @@ export default function WebViewExample() {
         source={{
           uri: 'https://www.qq.com',
           method: 'get',
-          userAgent: `Mozilla/5.0 (Linux; U; Android 5.1.1;
-            zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2
+          userAgent: `Mozilla/5.0 (Linux; U; Android 5.1.1; \
+            zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2 \
             Mobile Safari/537.36`,
         }}
         style={styles.webViewStyle}

--- a/examples/hippy-react-demo/src/components/WebView/index.jsx
+++ b/examples/hippy-react-demo/src/components/WebView/index.jsx
@@ -32,9 +32,9 @@ export default function WebViewExample() {
         source={{
           uri: 'https://www.qq.com',
           method: 'get',
-          userAgent: 'Mozilla/5.0 (Linux; U; Android 5.1.1; \
-            zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2 \
-            Mobile Safari/537.36',
+          userAgent: 'Mozilla/5.0 (Linux; U; Android 5.1.1; ' +
+            'zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2 ' +
+            'Mobile Safari/537.36',
         }}
         style={styles.webViewStyle}
       />

--- a/examples/hippy-react-demo/src/components/WebView/index.jsx
+++ b/examples/hippy-react-demo/src/components/WebView/index.jsx
@@ -32,9 +32,9 @@ export default function WebViewExample() {
         source={{
           uri: 'https://www.qq.com',
           method: 'get',
-          userAgent: `Mozilla/5.0 (Linux; U; Android 5.1.1; \
+          userAgent: 'Mozilla/5.0 (Linux; U; Android 5.1.1; \
             zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2 \
-            Mobile Safari/537.36`,
+            Mobile Safari/537.36',
         }}
         style={styles.webViewStyle}
       />


### PR DESCRIPTION
CRLF in header will make the android webview crash.

SEE:
https://github.com/chromium/chromium/blob/master/net/http/http_request_headers.cc#L152
https://github.com/chromium/chromium/blob/master/net/http/http_util.h#L106

Fix the following error
```
[ERROR:http_request_headers.cc(152)] "User-Agent: Mozilla/5.0 (Linux; U; Android 5.1.1;
                zh-cn; vivo X7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/8.2
                Mobile Safari/537.36" has invalid header value.
```

Before submitting a new pull request, please make sure:

- [x] Test cases have been added/updated for the code you will submit.
- [x] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
