### PR TITLE
fix(vue): setStyle px unit determine.

### DIFF
--- a/packages/hippy-vue/src/renderer/element-node.js
+++ b/packages/hippy-vue/src/renderer/element-node.js
@@ -11,6 +11,7 @@ import {
   unicodeToChar,
   tryConvertNumber,
   setsAreEqual,
+  endsWith,
 } from '../util';
 import Native from '../runtime/native';
 
@@ -168,8 +169,8 @@ class ElementNode extends ViewNode {
           if (property.toLowerCase().indexOf('color') >= 0) {
             v = colorParser(v, Native.Platform);
           // Convert inline length style, drop the px unit
-          } else if (v.indexOf('px') === v.length - 2) {
-            v = parseFloat(value.slice(0, value.indexOf('px')));
+          } else if (endsWith(v, 'px')) {
+            v = parseFloat(value.slice(0, value.length - 2));
           } else {
             v = tryConvertNumber(v);
           }

--- a/packages/hippy-vue/src/util/__tests__/index.test.js
+++ b/packages/hippy-vue/src/util/__tests__/index.test.js
@@ -110,3 +110,15 @@ test('setsAreEqual test', (t) => {
   });
   t.is(err2.message, 'as.values is not a function');
 });
+
+test('endsWith test', (t) => {
+  t.true(util.endsWith('100px', 'px'));
+  t.false(util.endsWith('100', 'px'));
+  t.true(util.endsWith('px', 'px'));
+  t.false(util.endsWith('x', 'px'));
+  delete String.prototype.endsWith;
+  const str = 'To be, or not to be, that is the question.';
+  t.true(util.endsWith(str, 'question.'));
+  t.false(util.endsWith(str, 'to be'));
+  t.true(util.endsWith(str, 'to be', 19));
+});

--- a/packages/hippy-vue/src/util/index.js
+++ b/packages/hippy-vue/src/util/index.js
@@ -117,6 +117,27 @@ function setsAreEqual(as, bs) {
   return true;
 }
 
+/**
+ * endsWith polyfill for iOS 8 compatiblity
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Polyfill
+ *
+ * @param {string} str - The characters with specified string.
+ * @param {string} search - The characters to be searched for at the end of str.
+ * @param {number} length - If provided, it is used as the length of str. Defaults to str.length.
+ * @return {boolean}
+ */
+function endsWith(str, search, length) {
+  if (String.prototype.endsWith) {
+    return str.endsWith(search, length);
+  }
+  let strLen = length;
+  if (strLen === undefined || strLen > str.length) {
+    strLen = str.length;
+  }
+  return str.slice(strLen - search.length, strLen) === search;
+}
+
 export {
   VUE_VERSION,
   HIPPY_VUE_VERSION,
@@ -132,4 +153,5 @@ export {
   arrayCount,
   isFunction,
   setsAreEqual,
+  endsWith,
 };


### PR DESCRIPTION
The old implementation of setStyle('flex', 1), will enter into parseFloat logic and returns NaN.

Before submitting a new pull request, please make sure:

- [X] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [X] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [X] Squash the repeat code commits, short patches are welcome.
