### PR TITLE
fix(hippy-react): Text component text repeated rendering

### DIFF
--- a/packages/hippy-react/src/components/text.tsx
+++ b/packages/hippy-react/src/components/text.tsx
@@ -82,6 +82,7 @@ function Text({ style, ...nativeProps }: TextProps) {
       .filter(t => typeof t === 'string' || typeof t === 'number')
       .join('');
     nativeProps.text = unicodeToChar(text);
+    nativeProps.children = nativeProps.text;
   }
 
   return (


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [x] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
```
<Text>{"A"}B</Text>
```
rendered as `AB AB`,expected is `AB`.

```
<Text>{"A"} </Text>
```
rendered as `A A `,expected is `A `