### PR TITLE
fix(android): treat Parcelable[] as Bundle[]

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/utils/ArgumentUtils.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/utils/ArgumentUtils.java
@@ -564,15 +564,18 @@ public class ArgumentUtils
 				catalystArray.pushString(str);
 			}
 		}
-		else if (array instanceof Bundle[])
+		else if (array instanceof Parcelable[])
 		{
-			Bundle[] bundles = (Bundle[]) ((Bundle[]) array);
-			length = bundles.length;
+      Parcelable[] parcelables = (Parcelable[]) ((Parcelable[]) array);
+			length = parcelables.length;
 
 			for (index = 0; index < length; ++index)
 			{
-				Bundle bundle = bundles[index];
-				catalystArray.pushMap(fromBundle(bundle));
+				Parcelable parcelable = parcelables[index];
+				if (parcelable instanceof Bundle)
+				{
+          catalystArray.pushMap(fromBundle((Bundle) parcelable));
+        }
 			}
 		}
 		else if (array instanceof int[])


### PR DESCRIPTION
### Problem

`Bundle[]` will be recognized as `Parcelable[]` after a Bundle is unmarshalled. 

- A `Bundle[]` instance can only be passed into another Bundle by `putParcelableArray()`
- When starting an activity with `Intent.putExtras()`, the `Bundle[]` instance will be converted into a `Parcelable[]` instance
- When converting a bundle with `Parcelable[]` instances (actually `Bundle[]` instances), the unrecognized type will cause a exception. 

### Solution

- treat any `Parcelable[]` instance as `Bundle[]` instance when converting arrays
- only `Bundle` subelements will be converted into `HippyMap`