### PR TITLE
fix(android) imageview will flash when list loadmore

### DIFF
--- a/android/support_ui/src/main/java/com/tencent/mtt/supportui/views/asyncimage/AsyncImageView.java
+++ b/android/support_ui/src/main/java/com/tencent/mtt/supportui/views/asyncimage/AsyncImageView.java
@@ -395,7 +395,11 @@ public class AsyncImageView extends ViewGroup implements Animator.AnimatorListen
 			setContent(SOURCE_TYPE_DEFAULT_SRC);
 			setUrl(mUrl);
 		}
-		fetchImageByUrl(mUrl, SOURCE_TYPE_SRC);
+		// 避免不必要的图片加载
+    // listview item中的imageView会在刷新时重新执行detach->attach，如果重新拉取图片，会导致闪烁
+		if (getBitmap() == null) {
+      fetchImageByUrl(mUrl, SOURCE_TYPE_SRC);
+    }
 		onDrawableAttached();
 	}
 


### PR DESCRIPTION
修正下拉刷新时，listview中的imageview由于被移除后重新加回viewTree导致的重新加载图片而闪烁的问题
https://github.com/Tencent/Hippy/issues/120