### PR TITLE
Make fetch redirect mode to follow as default to fit the standard.

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/modules/nativemodules/network/NetworkModule.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/modules/nativemodules/network/NetworkModule.java
@@ -126,13 +126,23 @@ public class NetworkModule extends HippyNativeModuleBase
 		httpRequest.setConnectTimeout(10 * 1000);
 		httpRequest.setReadTimeout(10 * 1000);
 		String redirect = request.getString("redirect");
-		if (!TextUtils.isEmpty(redirect) && TextUtils.equals("follow", redirect))
-		{
-			httpRequest.setInstanceFollowRedirects(true);
-		}
-		else
-		{
-			httpRequest.setInstanceFollowRedirects(false);
+
+		// Get the redirect mode
+		// https://fetch.spec.whatwg.org/#concept-request-redirect-mode
+		if (!TextUtils.isEmpty(redirect)) {
+			switch(redirect) {
+				case "error":
+					// TODO: error redirect mode implementation.
+				case "manual": {
+					httpRequest.setInstanceFollowRedirects(false);
+					break;
+				}
+				default: {
+					// Use "follow" redirect mode as default
+					httpRequest.setInstanceFollowRedirects(true);
+				}
+
+			}
 		}
 		httpRequest.setUseCaches(false);
 		httpRequest.setMethod(method);

--- a/ios/sdk/module/network/HippyNetWork.m
+++ b/ios/sdk/module/network/HippyNetWork.m
@@ -87,8 +87,19 @@ HIPPY_EXPORT_METHOD(fetch:(NSDictionary *)params resolver:(__unused HippyPromise
             [request setHTTPBody: postData];
         }
     }
+    // Get the redirect mode
+    // https://fetch.spec.whatwg.org/#concept-request-redirect-mode
     NSString *redirect = params[@"redirect"];
-    BOOL report302Status = (nil == redirect || [redirect isEqualToString:@"manual"]);
+    NSArray *redirectModes = @[@"follow", @"manual", @"error"];
+    unsigned short redirectMode = [redirectModes indexOfObject:redirect];
+    BOOL report302Status = nil;
+    switch (redirectMode) {
+        case 2:
+            // TODO: error redirect mode implementation.
+        case 1:
+            report302Status = true;
+            break;
+    }
     HippyFetchInfo *fetchInfo = [[HippyFetchInfo alloc] initWithResolveBlock:resolve rejectBlock:reject report302Status:report302Status];
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
     sessionConfiguration.protocolClasses = [self protocolClasses];


### PR DESCRIPTION
It's manual as default redirect mode so far, but it's a mistake.

Should be 'follow'.

https://fetch.spec.whatwg.org/#concept-request-redirect-mode

Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [X] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [X] Squash the repeat code commits, short patches are welcome.
