### PR TITLE
feat(ios): added block to handle hippy default views

### DIFF
--- a/examples/ios-demo/HippyDemo/ViewController.m
+++ b/examples/ios-demo/HippyDemo/ViewController.m
@@ -22,6 +22,7 @@
 
 #import "ViewController.h"
 #import "HippyRootView.h"
+#import "HippyUIManager.h"
 
 @interface ViewController ()<HippyBridgeDelegate>
 
@@ -41,6 +42,9 @@
     NSString *commonBundlePath = [[NSBundle mainBundle] pathForResource:@"vendor.ios" ofType:@"js" inDirectory:@"res"];
     NSString *businessBundlePath = [[NSBundle mainBundle] pathForResource:@"index.ios" ofType:@"js" inDirectory:@"res"];
     HippyBridge *bridge = [[HippyBridge alloc] initWithDelegate:self bundleURL:[NSURL fileURLWithPath:commonBundlePath] moduleProvider:nil launchOptions:nil];
+    [bridge.uiManager addCreateHippyViewBlock:^(UIView *hippyView, NSNumber *hippyTag) {
+        // Optional. executed when a hippy view has created
+    }];
     HippyRootView *rootView = [[HippyRootView alloc] initWithBridge:bridge businessURL:[NSURL fileURLWithPath:businessBundlePath] moduleName:@"Demo" initialProperties:  @{@"isSimulator": @(isSimulator)} launchOptions:nil shareOptions:nil debugMode:NO delegate:nil];
     rootView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     rootView.frame = self.view.bounds;

--- a/ios/sdk/component/view/HippyViewManager.h
+++ b/ios/sdk/component/view/HippyViewManager.h
@@ -36,7 +36,7 @@
 
 typedef void (^HippyViewManagerUIBlock)(HippyUIManager *uiManager, NSDictionary<NSNumber *,__kindof UIView *> *viewRegistry);
 
-typedef UIView* (^CreateHippyViewWithPropsBlock)(HippyBridge *bridge, NSString *classname, NSDictionary *props);
+typedef void (^CreateHippyViewBlock)(UIView *hippyView, NSNumber *hippyTag);
 
 
 @interface HippyViewManager : NSObject <HippyBridgeModule>

--- a/ios/sdk/module/uimanager/HippyUIManager.h
+++ b/ios/sdk/module/uimanager/HippyUIManager.h
@@ -110,6 +110,9 @@ HIPPY_EXTERN NSString *const HippyUIManagerRootViewKey;
 
 - (void)executeBlockOnUIManagerQueue:(dispatch_block_t)block;
 
+/// Schedule a block to be executed when a hippy view has created.
+- (void)addCreateHippyViewBlock:(CreateHippyViewBlock)block;
+
 /**
  * Given a hippyTag from a component, find its root view, if possible.
  * Otherwise, this will give back nil.


### PR DESCRIPTION
框架内的视图实现了大部分基础的逻辑。但是对于特殊的业务逻辑，业务没有必要创建一个自定义视图，copy框架内的实现代码，然后就为了修改一两行代码。

在hippy创建view的时候通过block的方式，回调出view和对应的hippyTag，这样业务使用侧就有机会在view生命周期开始时获取到，进而通过hook等方式增加自己的业务逻辑。
