### PR TITLE
fix(ios): set default image need not update imageview

### DIFF
--- a/ios/sdk/component/image/HippyImageView.m
+++ b/ios/sdk/component/image/HippyImageView.m
@@ -189,10 +189,13 @@ UIImage *HippyBlurredImageWithRadiusv(UIImage *inputImage, CGFloat radius)
 
 - (void)setDefaultImage:(UIImage *)defaultImage
 {
-	if (_defaultImage != defaultImage) {
-		_defaultImage = defaultImage;
-        [self updateImage:_defaultImage];
-	}
+    if (_defaultImage != defaultImage) {
+        BOOL shouldUpdateImage = (self.image == _defaultImage);
+        _defaultImage = defaultImage;
+        if (shouldUpdateImage) {
+            [self updateImage:_defaultImage];
+        }
+    }
 }
 
 - (void)setCapInsets:(UIEdgeInsets)capInsets


### PR DESCRIPTION
设置defaultImage的时候，如果当前hippyImageView已经展示图片而不是占位图，不应该更新图片。

触发场景：正常列表已经加载成功，这个时候切换日夜间模式，前端需要替换对应的占位图样式，此时已经加载好的图片被更新成了占位图。