### PR TITLE
fix: enable Scroll-to-Change-Tab in content area

### DIFF
--- a/examples/hippy-react-demo/src/externals/TabHost/index.jsx
+++ b/examples/hippy-react-demo/src/externals/TabHost/index.jsx
@@ -164,6 +164,7 @@ export default class TabHostExample extends React.Component {
           }}
           style={{ flex: 1 }}
           initialPage={0}
+          scrollEnabled={true}
           onPageSelected={e => this.onViewPagerChange(e.position)}
         >
           {navList.map((v, idx) => TabHostExample.getPage(v, idx))}


### PR DESCRIPTION
TabHost 内容区域左右滑动不能切换 tab, 显式补充 scrollEnabled = true 就 OK 了.
