### PR TITLE
fix(android): the truncation happens too early with Android StaticLayout

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/dom/node/TextNode.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/dom/node/TextNode.java
@@ -648,14 +648,14 @@ public class TextNode extends StyleNode
 			if (layout.getLineCount() > mNumberOfLines)
 			{
 				int lastLineStart = layout.getLineStart(mNumberOfLines - 1);
-				int lastLineEnd = layout.getLineEnd(mNumberOfLines - 1);
+				int lastLineEnd = layout.getLineEnd(mNumberOfLines);
 				if (lastLineStart < lastLineEnd)
 				{
 					layout = createLayoutWithNumberOfLine(lastLineStart, lastLineEnd, layout.getWidth());
 				}
 			}
 		}
-		
+
 		layout.getPaint().setTextSize(mFontSize);
 		return layout;
 	}


### PR DESCRIPTION
### Problem

Android `StaticLayout` truncates too early when there is a long-length word. 

![image](https://user-images.githubusercontent.com/5073922/83385145-4cee9d80-a41b-11ea-97a2-8fdefb4cddab.png)

while the expected truncation should be like 

![image](https://user-images.githubusercontent.com/5073922/83385208-68f23f00-a41b-11ea-99b4-31617f21673e.png)

### Solution

When truncating, take the chars from next line into consideration. 