### PR TITLE
feat(vue-css-loader): color-parser supports parsing multi colors

### DIFF
--- a/packages/hippy-vue-css-loader/src/__tests__/color-parser.test.js
+++ b/packages/hippy-vue-css-loader/src/__tests__/color-parser.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import translateColor from '../color-parser';
+import translateColor, { translateColors } from '../color-parser';
 
 test('Test color translation', (t) => {
   t.is(translateColor('#abc'), 4289379276);
@@ -19,6 +19,21 @@ test('Test color translation', (t) => {
   t.is(translateColor('transparent'), 0);
   t.is(translateColor('blueviolet'), 4287245282);
   t.is(translateColor(4287245282), 3808397867);
+});
+
+test('Test colors translation', (t) => {
+  // single color
+  t.deepEqual(translateColors('#abc'), [4289379276]);
+  t.deepEqual(translateColors('transparent'), [0]);
+  t.deepEqual(translateColors('rgb(10, 20, 30)'), [4278850590]);
+  t.deepEqual(translateColors('rgba(10, 20, 30, .8)'), [3423212574]);
+  t.deepEqual(translateColors('hsla(100, 40%, 50%, .8)'), [3429806925]);
+  t.deepEqual(translateColors('hsla(100, -10%, 120%, .8)'), [3439329279]);
+  // multi colors
+  t.deepEqual(translateColors('#abc, #abcd'), [4289379276, 3718953932]);
+  t.deepEqual(translateColors('transparent, #abcd'), [0, 3718953932]);
+  t.deepEqual(translateColors('#abc, rgb(10, 20, 30)'), [4289379276, 4278850590]);
+  t.deepEqual(translateColors('#abc, rgb(10, 20, 30), hsla(100, 40%, 50%, .8)'), [4289379276, 4278850590, 3429806925]);
 });
 
 test('Test color translation error handle NaN', (t) => {
@@ -46,4 +61,9 @@ test('Test color translation error handle #0 and #01', (t) => {
 test('Test color translation error handle abc', (t) => {
   const err = t.throws(() => translateColor('abc'));
   t.is(err.message, 'Bad color value: abc');
+});
+
+test('Test colors translation error handle "red, blue, , yellow"', (t) => {
+  const err = t.throws(() => translateColors('red, blue, , yellow'));
+  t.is(err.message, 'Bad color value: ');
 });

--- a/packages/hippy-vue-css-loader/src/color-parser.js
+++ b/packages/hippy-vue-css-loader/src/color-parser.js
@@ -351,4 +351,39 @@ function translateColor(color, options = {}) {
   return int32Color;
 }
 
+/**
+ * translate multi colors
+ * @param {String | String[]} colors Colors likes "red, rgba(10, 20, 9, 0.6), #333"
+ * @param {{ platform: String }} options
+ * @returns {Number[]}
+ */
+function translateColors(colors, options) {
+  let colorsArray = [];
+  if (typeof colors === 'string') {
+    const colorsMetaArray = colors.split(',');
+    // meta after splitted like:
+    // before: "red, rgb(10,20,10), #333"
+    // after: ["red", " rgba(10", "20", "10)", " #333"]
+    let endFlagDepth = 0;
+    colorsMetaArray.reduce((res, color) => {
+      if (endFlagDepth) {
+        res[res.length - 1] += `,${color.trim()}`;
+      } else {
+        res.push(color.trim());
+      }
+      if (color.indexOf('(') >= 0) {
+        endFlagDepth += 1;
+      } else if (color.indexOf(')') >= 0) {
+        endFlagDepth -= 1;
+      }
+      return res;
+    }, colorsArray);
+  } else if (Array.isArray(colors)) {
+    colorsArray = colors;
+  }
+  return colorsArray.map(color => translateColor(color.trim(), options));
+}
+
+export { translateColor, translateColors };
+
 export default translateColor;

--- a/packages/hippy-vue-css-loader/src/index.js
+++ b/packages/hippy-vue-css-loader/src/index.js
@@ -3,7 +3,7 @@
 import { getOptions } from 'loader-utils';
 import { GLOBAL_STYLE_NAME } from '@vue/runtime/constants';
 import parseCSS from './css-parser';
-import translateColor from './color-parser';
+import { translateColor, translateColors } from './color-parser';
 
 let sourceId              = 0;
 
@@ -20,8 +20,13 @@ function hippyVueCSSLoader(source) {
       declarations: n.declarations.map((dec) => {
         let { value } = dec;
         // FIXME: Should have a strict property with colors map.
-        if (dec.property && dec.property.toLowerCase().indexOf('color') > -1) {
-          value = translateColor(value, options);
+        if (dec.property) {
+          const propertyName = dec.property.toLowerCase();
+          if (propertyName.indexOf('colors') > -1) {
+            value = translateColors(value, options);
+          } else if (propertyName.indexOf('color') > -1) {
+            value = translateColor(value, options);
+          }
         }
         return {
           type: dec.type,


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [X] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [X] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [X] Squash the repeat code commits, short patches are welcome.

# feat(vue-css-loader): color-parser supports parsing multi colors

- **意图**：

`color-parser` 支持多色值写法转换。如下示意：

`css` 写法：
``` css
.test {
  colors: #abc, rgb(10, 20, 30);
}
```
最终 `value` 将转换成 `Number[]`:
``` js
{
  property: "colors",
  value: [4289379276, 4278850590]
}
```

- **改动点**：

  - `color-parser.js` 新增多色值转换函数 `translateColors` 方法
  - `css-loader/index` 新增判断逻辑，命中 `colors` 关键字时走多色值转换函数
  - 测试用例增加 (`color-parser.test.js`)
