### PR TITLE
fix(android): skip dismiss when activity finish

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/views/modal/HippyModalHostView.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/views/modal/HippyModalHostView.java
@@ -156,7 +156,8 @@ public class HippyModalHostView extends HippyViewGroup implements HippyInstanceL
 	{
 		if (mDialog != null)
 		{
-			mDialog.dismiss();
+			boolean isFinishing = (mDialog.getContext() instanceof Activity) && ((Activity) mDialog.getContext()).isFinishing();
+			if (!isFinishing) mDialog.dismiss();
 			mDialog = null;
 			ViewGroup parent = (ViewGroup) mHostView.getParent();
 			parent.removeViewAt(0);


### PR DESCRIPTION
Add a validation, to prevent `java.lang.IllegalArgumentException`. 

Ref: https://stackoverflow.com/questions/22924825/view-not-attached-to-window-manager-crash