### PR TITLE
feat(hippy-react-web): support isomorphic rendering

### DIFF
--- a/packages/hippy-react-web/src/adapters/apply-layout.ts
+++ b/packages/hippy-react-web/src/adapters/apply-layout.ts
@@ -54,7 +54,9 @@ const triggerAll = () => {
     });
 };
 
-window.addEventListener('resize', debounce(triggerAll, 16), false);
+if (typeof window === 'object') {
+  window.addEventListener('resize', debounce(triggerAll, 16), false);
+}
 
 function observe(instance: LayoutElement) {
   id += 1;

--- a/packages/hippy-react-web/src/index.ts
+++ b/packages/hippy-react-web/src/index.ts
@@ -32,6 +32,18 @@ const Dimensions = {
   get(name: 'window' | 'screen') {
     return Device[name];
   },
+  set(dimensions: { window?: typeof Device['window']; screen?: typeof Device['screen'] }) {
+    if (typeof window === 'object') {
+      console.error('Dimensions cannot be set in the browser');
+      return;
+    }
+    if (dimensions.window) {
+      Device.window = dimensions.window;
+    }
+    if (dimensions.screen) {
+      Device.screen = dimensions.screen;
+    }
+  },
 };
 
 const PixelRatio = {
@@ -40,7 +52,7 @@ const PixelRatio = {
   },
 };
 
-const AsyncStorage = localStorage;
+const AsyncStorage = typeof window === 'object' ? localStorage : null;
 const ImageBackground = Image;
 
 export default HippyReact;

--- a/packages/hippy-react-web/src/native.ts
+++ b/packages/hippy-react-web/src/native.ts
@@ -1,16 +1,20 @@
 /* eslint-disable import/prefer-default-export */
 
+const globalThis =  typeof window === 'object'
+  ? window
+  : { innerHeight: 0, innerWidth: 0, screen: { height: 0, width: 0 } };
+
 const Device = {
   platform: 'web',
   window: {
-    height: window.innerHeight,
-    width: window.innerWidth,
+    height: globalThis.innerHeight,
+    width: globalThis.innerWidth,
     scale: 1,
     statusBarHeight: 0,
   },
   screen: {
-    height: window.screen.height,
-    width: window.screen.width,
+    height: globalThis.screen.height,
+    width: globalThis.screen.width,
     scale: 1,
     statusBarHeight: 0,
   },


### PR DESCRIPTION
@hippy/react-web 支持服务端渲染，主要变动内容：

- 判断 `window` 和 `localStorage` 变量是否非空
- 在服务端环境下，支持设置 Dimensions 数值，这里参考 https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/Dimensions/index.js#L51-L60
 