### PR TITLE
fix(hippy-react): text will be blank if changed on android

### DIFF
--- a/packages/hippy-react/src/components/text.tsx
+++ b/packages/hippy-react/src/components/text.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Style from '@localTypes/style';
 import { LayoutableProps, ClickableProps } from '../types';
 import { unicodeToChar } from '../utils';
+import { Device } from '../global';
 
 interface TextProps extends LayoutableProps, ClickableProps {
   /**
@@ -80,6 +81,13 @@ function Text({ style, ...nativeProps }: TextProps) {
       nativeProps.text = unicodeToChar(text);
       nativeProps.children = nativeProps.text;
     }
+  }
+
+  if (
+    (__PLATFORM__ === 'android' || Device.platform.OS === 'android')
+    && (typeof nativeProps.key !== 'string' && typeof nativeProps.key !== 'number')
+  ) {
+    nativeProps.key = nativeProps.text;
   }
 
   return (


### PR DESCRIPTION
在 Android 端，`<Text />` 组件文字更变后，会显示空白。
解决方案是给组件增加 `key` 字段，`key` 值以文字内容为准。
经测试如果 `key` 不变，即文字内容不变，不会重新渲染。

```jsx
class Index extends Component {
  state = { isLoaded: false }

  componentDidMount() {
    setTimeout(() => {
      this.setState({ isLoaded: true })
    }, 1000)
  }

  render() {
    const { isLoaded } = this.state
    // 变量 isLoaded 从 false 变成 true 后，Android 端显示空白，iOS 和 Web 均正常
    return (
      <View>
        <Text>{isLoaded ? 'Index page loaded' : 'Index loading...'}</Text>
      </View>
    )
  }
}
```