### PR TITLE
fix(hippy-vue): fix registerElement elem name and comp name problem

### DIFF
--- a/packages/hippy-vue/src/elements/__tests__/index.test.js
+++ b/packages/hippy-vue/src/elements/__tests__/index.test.js
@@ -2,11 +2,13 @@ import test from 'ava';
 import * as elements from '../index';
 
 const EMPTY_TAG_NAME = 'test';
+const CUSTOM_ELEM = 'custom-comp';
+const CUSTOM_COMP = 'CustomComp';
 
 test.before(() => {
   elements.registerElement(EMPTY_TAG_NAME, {
     component: {
-      name: 'Test',
+      name: 'TestComp',
     },
   });
 });
@@ -96,4 +98,22 @@ test('registerElement with mustUseProp', (t) => {
   t.is(viewMeta.component.name, 'Test');
   t.true(viewMeta.mustUseProp('testAttr'));
   t.false(viewMeta.mustUseProp());
+});
+
+test('register element with mustUseProp, and element name after camelCase-converted is the same with component name ', (t) => {
+  const err = t.throws(() => {
+    elements.registerElement(CUSTOM_ELEM, {
+      component: {
+        name: CUSTOM_COMP,
+      },
+    });
+  }, Error);
+  t.is(err.message, `Cannot registerElement with kebab-case name ${CUSTOM_ELEM}, which converted to camelCase is the same with component.name ${CUSTOM_COMP}, please make them different`);
+});
+
+test('register element with empty name', (t) => {
+  const err = t.throws(() => {
+    elements.registerElement('');
+  }, Error);
+  t.is(err.message, 'RegisterElement cannot set empty name');
 });

--- a/packages/hippy-vue/src/elements/index.js
+++ b/packages/hippy-vue/src/elements/index.js
@@ -1,5 +1,6 @@
-import { makeMap } from 'shared/util';
+import { makeMap, camelize } from 'shared/util';
 import * as BUILT_IN_ELEMENTS from './built-in';
+import { capitalizeFirstLetter } from '../util';
 
 const isReservedTag = makeMap(
   'template,script,style,element,content,slot,'
@@ -36,6 +37,9 @@ function normalizeElementName(elementName) {
 }
 
 function registerElement(elementName, oldMeta) {
+  if (!elementName) {
+    throw new Error('RegisterElement cannot set empty name');
+  }
   const normalizedName = normalizeElementName(elementName);
 
   const meta = { ...defaultViewMeta, ...oldMeta };
@@ -48,6 +52,10 @@ function registerElement(elementName, oldMeta) {
     ...getDefaultComponent(elementName, meta, normalizedName),
     ...meta.component,
   };
+
+  if (meta.component.name && meta.component.name === capitalizeFirstLetter(camelize(elementName))) {
+    throw new Error(`Cannot registerElement with kebab-case name ${elementName}, which converted to camelCase is the same with component.name ${meta.component.name}, please make them different`);
+  }
 
   const entry = {
     meta,


### PR DESCRIPTION
Cannot registerElement with kebab-case name  which converted to camelCase is the same with component.name

Before submitting a new pull request, please make sure:

- [x] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
