### PR TITLE
fix(android): avoid `Serializer` exceptions when long value

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/bridge/HippyBridgeManagerImpl.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/bridge/HippyBridgeManagerImpl.java
@@ -166,12 +166,14 @@ public class HippyBridgeManagerImpl implements HippyBridgeManager, HippyBridge.B
       if (enableV8Serialization) {
         if (safeDirectWriter == null) {
           safeDirectWriter = new SafeDirectWriter(SafeDirectWriter.INITIAL_CAPACITY, 0);
+        } else {
+          safeDirectWriter.reset();
         }
         serializer.setWriter(safeDirectWriter);
         serializer.reset();
         serializer.writeHeader();
         serializer.writeValue(msg.obj);
-        buffer = serializer.getWriter().chunked();
+        buffer = safeDirectWriter.chunked();
       } else {
         mStringBuilder.setLength(0);
         byte[] bytes = new byte[0];
@@ -189,12 +191,14 @@ public class HippyBridgeManagerImpl implements HippyBridgeManager, HippyBridge.B
       if (enableV8Serialization) {
         if (safeHeapWriter == null) {
           safeHeapWriter = new SafeHeapWriter();
+        } else {
+          safeHeapWriter.reset();
         }
         serializer.setWriter(safeHeapWriter);
         serializer.reset();
         serializer.writeHeader();
         serializer.writeValue(msg.obj);
-        ByteBuffer buffer = serializer.getWriter().chunked();
+        ByteBuffer buffer = safeHeapWriter.chunked();
         int offset = buffer.arrayOffset() + buffer.position();
         int length = buffer.limit() - buffer.position();
         mHippyBridge.callFunction(action, callback, buffer.array(), offset, length);

--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/PrimitiveValueSerializer.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/PrimitiveValueSerializer.java
@@ -127,15 +127,14 @@ public abstract class PrimitiveValueSerializer extends SharedSerialization {
           writer.putVarint(longValue);
         } else {
           writeTag(SerializationTag.DOUBLE);
-          writer.putDouble((double) value);
+          writer.putDouble(((Number) value).doubleValue());
         }
       } else if (value instanceof BigInteger) {
         writeTag(SerializationTag.BIG_INT);
         writeBigIntContents((BigInteger) value);
       } else {
-        double doubleValue = ((Number) value).doubleValue();
         writeTag(SerializationTag.DOUBLE);
-        writer.putDouble(doubleValue);
+        writer.putDouble(((Number) value).doubleValue());
       }
     } else if (value == Boolean.TRUE) {
       writeTag(SerializationTag.TRUE);

--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/BinaryWriter.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/BinaryWriter.java
@@ -75,10 +75,17 @@ public interface BinaryWriter {
   int length(int length);
 
   /**
-   * Chunked the write operation and returns a wrapped {@link ByteBuffer} object. After calling this
-   * method, writer will be reset and write from the beginning.
+   * Chunked the write operation and returns a wrapped {@link ByteBuffer} object.
+   * After calling this method, writer will be reset and write from the beginning.
    *
    * @return wrapped byte buffer
    */
   ByteBuffer chunked();
+
+  /**
+   * After calling this method, writer will be reset and write from the beginning.
+   *
+   * @return This writer
+   */
+  BinaryWriter reset();
 }

--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/SafeDirectWriter.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/SafeDirectWriter.java
@@ -122,13 +122,16 @@ public final class SafeDirectWriter extends AbstractBinaryWriter {
   @Override
   public ByteBuffer chunked() {
     value.flip();
-    ByteBuffer chunked;
-    if (value.limit() < maxCapacity) {
-      chunked = value.duplicate();
-    } else {
-      chunked = value;
+    ByteBuffer chunked = value.duplicate();
+    reset();
+    return chunked;
+  }
+
+  @Override
+  public BinaryWriter reset() {
+    if (value.capacity() >= maxCapacity) {
       value = ByteBuffer.allocateDirect(initialCapacity);
     }
-    return chunked;
+    return this;
   }
 }

--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/SafeHeapWriter.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/nio/writer/SafeHeapWriter.java
@@ -143,10 +143,16 @@ public final class SafeHeapWriter extends AbstractBinaryWriter {
   @Override
   public final ByteBuffer chunked() {
     ByteBuffer chunked = ByteBuffer.wrap(value, 0, count);
+    reset();
+    return chunked;
+  }
+
+  @Override
+  public BinaryWriter reset() {
     if (count >= maxCapacity) {
       value = new byte[initialCapacity];
     }
     count = 0;
-    return chunked;
+    return this;
   }
 }


### PR DESCRIPTION
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
