### PR TITLE
fix(hippy-react-web): correct lineHeight style values

### DIFF
--- a/packages/hippy-react-web/src/adapters/transfer.ts
+++ b/packages/hippy-react-web/src/adapters/transfer.ts
@@ -216,7 +216,10 @@ function hackWebStyle(webStyle_: any) {
     });
   }
 
-  toPx(webStyle.lineHeight);
+  // 处理lineHeight
+  if (hasOwnProperty(webStyle, 'lineHeight')) {
+    webStyle.lineHeight = toPx(webStyle.lineHeight);
+  }
 
   if (!webStyle.position) {
     webStyle.position = 'relative';

--- a/packages/hippy-react-web/src/adapters/transfer.ts
+++ b/packages/hippy-react-web/src/adapters/transfer.ts
@@ -216,7 +216,7 @@ function hackWebStyle(webStyle_: any) {
     });
   }
 
-  // 处理lineHeight
+  // hack lineHeight
   if (hasOwnProperty(webStyle, 'lineHeight')) {
     webStyle.lineHeight = toPx(webStyle.lineHeight);
   }


### PR DESCRIPTION
修复web端显示文字组件lineHeight异常
1. 文字组件lineHeight需传入带px单位的字符串
2. toPx函数不会直接去修改其传入参数，仅会返回修改后的值，这里需要手动修改webStyle.lineHeight