### PR TITLE
fix(android): getRenderNodeHeight headerEventHelper null crash

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/views/hippylist/HippyRecyclerListAdapter.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/views/hippylist/HippyRecyclerListAdapter.java
@@ -312,7 +312,11 @@ public class HippyRecyclerListAdapter<HRCV extends HippyRecyclerView> extends
     ListItemRenderNode childNode = getChildNode(position);
     if (childNode != null) {
       if (childNode.isPullHeader()) {
-        return headerEventHelper.getVisibleHeight();
+        if (headerEventHelper != null) {
+          return headerEventHelper.getVisibleHeight();
+        }
+
+        return 0;
       }
       return childNode.getHeight();
     }


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
