### PR TITLE
fix(android): fix `hippy` library build script exception

### DIFF
--- a/android/sdk/src/main/jni/CMakeLists.txt
+++ b/android/sdk/src/main/jni/CMakeLists.txt
@@ -148,8 +148,10 @@ include_directories(${CORE_SRC_DIR}/third_party/base/include)
 add_library(${CMAKE_PROJECT_NAME} SHARED ${CORE_SRC} ${URL_PARSER_SRC} ${JNI_SRC})
 target_link_libraries(${CMAKE_PROJECT_NAME} ${HIPPY_DEPS})
 
-foreach(LIBRARY_DEP ${V8_LIBRARY_DEPS})
-  add_custom_command(
-          TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-          COMMAND ${CMAKE_COMMAND} -E copy ${V8_LIBRARY_PATH}/${LIBRARY_DEP} $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
-endforeach()
+if ((${JS_ENGINE} STREQUAL "V8") AND (${V8_LINKING_MODE} STREQUAL "shared"))
+  foreach(LIBRARY_DEP ${V8_LIBRARY_DEPS})
+    add_custom_command(
+            TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy ${V8_LIBRARY_PATH}/${LIBRARY_DEP} $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
+  endforeach()
+endif()


### PR DESCRIPTION
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [x] Squash the repeat code commits, short patches are welcome.
