### PR TITLE
fix(dom): rename RenderManagerProxy to LayerOptimizedRenderManager

### DIFF
--- a/dom/include/dom/layer_optimized_render_manager.h
+++ b/dom/include/dom/layer_optimized_render_manager.h
@@ -5,9 +5,9 @@
 namespace hippy {
 inline namespace dom {
 
-class RenderManagerProxy : public RenderManager {
+class LayerOptimizedRenderManager : public RenderManager {
  public:
-  RenderManagerProxy(std::shared_ptr<RenderManager> render_manager);
+  LayerOptimizedRenderManager(std::shared_ptr<RenderManager> render_manager);
 
   void CreateRenderNode(std::vector<std::shared_ptr<DomNode>>&& nodes) override;
   void UpdateRenderNode(std::vector<std::shared_ptr<DomNode>>&& nodes) override;


### PR DESCRIPTION
change the type of kJustLayoutProps from std::unordered_set to
std::array to avoid potential memory leak.

Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
