### PR TITLE
fix(ios): fix window not show with configured window scene

### DIFF
--- a/examples/ios-demo/HippyDemo.xcodeproj/project.pbxproj
+++ b/examples/ios-demo/HippyDemo.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		B21E4B3C270859C600B6A3ED /* js_native_turbo.cc in Sources */ = {isa = PBXBuildFile; fileRef = B21E4B3B270859C600B6A3ED /* js_native_turbo.cc */; };
 		B21E4B452708680900B6A3ED /* TurboConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = B21E4B412708680900B6A3ED /* TurboConfig.m */; };
 		B21E4B462708680900B6A3ED /* TurboBaseModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = B21E4B432708680900B6A3ED /* TurboBaseModule.mm */; };
+		EAB1F8EC277C969600C8AF79 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EAB1F8EB277C969600C8AF79 /* SceneDelegate.m */; };
 		F405949A2733C4A900157225 /* HippySRSIMDHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = F40594982733C4A900157225 /* HippySRSIMDHelpers.m */; };
 		F417B54D2727ACCE00894090 /* HippyDevManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F417B54C2727ACCE00894090 /* HippyDevManager.m */; };
 		F417B5532727B31200894090 /* HippyDevCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = F417B5522727B31200894090 /* HippyDevCommand.m */; };
@@ -612,6 +613,8 @@
 		B21E4B422708680900B6A3ED /* TurboBaseModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TurboBaseModule.h; sourceTree = "<group>"; };
 		B21E4B432708680900B6A3ED /* TurboBaseModule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TurboBaseModule.mm; sourceTree = "<group>"; };
 		B26F0FC62717D90F008F2640 /* HippyOCTurboModule+Inner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "HippyOCTurboModule+Inner.h"; sourceTree = "<group>"; };
+		EAB1F8EA277C969600C8AF79 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		EAB1F8EB277C969600C8AF79 /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		F40594982733C4A900157225 /* HippySRSIMDHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HippySRSIMDHelpers.m; sourceTree = "<group>"; };
 		F40594992733C4A900157225 /* HippySRSIMDHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HippySRSIMDHelpers.h; sourceTree = "<group>"; };
 		F417B54B2727ACCE00894090 /* HippyDevManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HippyDevManager.h; sourceTree = "<group>"; };
@@ -707,6 +710,8 @@
 				0612F02823A8BE320079E622 /* ViewController.m */,
 				0612F03223A8BE330079E622 /* Info.plist */,
 				0612F03323A8BE330079E622 /* main.m */,
+				EAB1F8EA277C969600C8AF79 /* SceneDelegate.h */,
+				EAB1F8EB277C969600C8AF79 /* SceneDelegate.m */,
 			);
 			path = HippyDemo;
 			sourceTree = "<group>";
@@ -1732,6 +1737,7 @@
 				85B77BFB2656BA8900303472 /* js_value_wrapper.cc in Sources */,
 				85BCD4582578C58000638DB4 /* engine.cc in Sources */,
 				064C5A4923AB1A51001E80DD /* HippyEventDispatcher.m in Sources */,
+				EAB1F8EC277C969600C8AF79 /* SceneDelegate.m in Sources */,
 				064C5A0123AB1A51001E80DD /* HippyExceptionModule.m in Sources */,
 				064C59EE23AB1A51001E80DD /* MTTTStyle.cpp in Sources */,
 				0612F02923A8BE320079E622 /* ViewController.m in Sources */,

--- a/examples/ios-demo/HippyDemo/AppDelegate.m
+++ b/examples/ios-demo/HippyDemo/AppDelegate.m
@@ -45,6 +45,9 @@
     */
 
     // Override point for customization after application launch.
+    if (@available(iOS 13, *)) {
+        return YES;
+    }
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     ViewController *vc = [ViewController new];
     [self.window setRootViewController: vc];

--- a/examples/ios-demo/HippyDemo/Info.plist
+++ b/examples/ios-demo/HippyDemo/Info.plist
@@ -2,6 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/examples/ios-demo/HippyDemo/SceneDelegate.h
+++ b/examples/ios-demo/HippyDemo/SceneDelegate.h
@@ -1,0 +1,34 @@
+/*!
+* iOS SDK
+*
+* Tencent is pleased to support the open source community by making
+* Hippy available.
+*
+* Copyright (C) 2019 THL A29 Limited, a Tencent company.
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(ios(13.0))
+@interface SceneDelegate : UIResponder<UISceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/examples/ios-demo/HippyDemo/SceneDelegate.m
+++ b/examples/ios-demo/HippyDemo/SceneDelegate.m
@@ -1,0 +1,72 @@
+/*!
+* iOS SDK
+*
+* Tencent is pleased to support the open source community by making
+* Hippy available.
+*
+* Copyright (C) 2019 THL A29 Limited, a Tencent company.
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import "SceneDelegate.h"
+#import "ViewController.h"
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
+    ViewController *vc = [ViewController new];
+    [self.window setRootViewController: vc];
+    [self.window makeKeyAndVisible];
+}
+
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+}
+
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+@end

--- a/ios/sdk/module/dev/HippyDevLoadingView.m
+++ b/ios/sdk/module/dev/HippyDevLoadingView.m
@@ -79,19 +79,29 @@ HIPPY_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backg
         if (!self->_window && !HippyRunningInTestEnvironment()) {
             CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
             CGFloat viewHeight = HippyDevMsgViewHeight;
+            CGFloat labelY = 0;
             if (@available(iOS 11.0, *)) {
                 UIEdgeInsets safeAreaInsets = HippyKeyWindow().safeAreaInsets;
                 if (safeAreaInsets.bottom > 0) {
                     //is iPhoneX
                     viewHeight += safeAreaInsets.top;
+                    labelY += safeAreaInsets.top;
                 }
             }
             self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenWidth, viewHeight)];
             self->_window.windowLevel = UIWindowLevelStatusBar + 1;
             // set a root VC so rotation is supported
             self->_window.rootViewController = [UIViewController new];
+            if (@available(iOS 13.0, *)) {
+                for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
+                    if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                        self->_window.windowScene = windowScene;
+                        break;
+                    }
+                }
+            }
             
-            self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];
+            self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self->_window.frame), HippyDevMsgViewHeight)];
             self->_label.font = [UIFont systemFontOfSize:12.0];
             self->_label.textAlignment = NSTextAlignmentCenter;
             

--- a/ios/sdk/module/dev/HippyRedBox.m
+++ b/ios/sdk/module/dev/HippyRedBox.m
@@ -397,6 +397,14 @@ HIPPY_EXPORT_MODULE()
         if (!self->_window) {
             self->_window = [[HippyRedBoxWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
             self->_window.actionDelegate = self;
+            if (@available(iOS 13.0, *)) {
+                for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
+                    if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                        self->_window.windowScene = windowScene;
+                        break;
+                    }
+                }
+            }
         }
         HippyErrorInfo *errorInfo = [[HippyErrorInfo alloc] initWithErrorMessage:message stack:stack];
         errorInfo = [self _customizeError:errorInfo];


### PR DESCRIPTION
Above iOS 13.0, If I configured windowscene configuration in my project's Info.plist, the RedBoxWindow will not be visible in my app. The custom window should be setting windowScene property.
