### PR TITLE
fix(ios) animatedImageView call displayLayer crash bug

### DIFF
--- a/ios/sdk/component/image/HippyAnimatedImageView.m
+++ b/ios/sdk/component/image/HippyAnimatedImageView.m
@@ -402,8 +402,16 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b) {
 #pragma mark Providing the Layer's Content
 
 - (void)displayLayer:(CALayer *)layer {
-    UIImage *image = self.image;
-    layer.contents = (__bridge id)image.CGImage;
+    if (self.animatedImage) {
+        UIImage *image = self.image;
+        layer.contents = (__bridge id)image.CGImage;
+    }
+    else {
+        // Only iOS 14+ UIImageView use this delegate method for rendering.
+        if ([UIImageView instancesRespondToSelector:@selector(displayLayer:)]) {
+            [super displayLayer:layer];
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
Fix https://github.com/Tencent/Hippy/issues/1688

in iOS 10~13, UIImageView does not implements this delegate method. See:
![86225664-214b0880-bbbd-11ea-8069-962f24043b25](https://user-images.githubusercontent.com/29303030/160528901-67cd326c-c328-4b19-b1c8-b71f14324926.png)

Only iOS 14+ implements this method:
![86228100-8f44ff00-bbc0-11ea-859d-98b5dc16b3a5](https://user-images.githubusercontent.com/29303030/160528921-379fdb1d-c9b6-43aa-ba30-877254898514.png)

Before submitting a new pull request, please make sure:

- [x] Test cases have been added/updated/passed for the code you will submit.
- [x] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [x] Squash the repeat code commits, short patches are welcome.
