### PR TITLE
fix(ios): fix image display crash

### DIFF
--- a/ios/sdk/component/image/HippyAnimatedImageView.m
+++ b/ios/sdk/component/image/HippyAnimatedImageView.m
@@ -402,13 +402,8 @@ static NSUInteger gcd(NSUInteger a, NSUInteger b) {
 #pragma mark Providing the Layer's Content
 
 - (void)displayLayer:(CALayer *)layer {
-    if (self.animatedImage) {
-        UIImage *image = self.image;
-        layer.contents = (__bridge id)image.CGImage;
-    }
-    else {
-        [super displayLayer:layer];
-    }
+    UIImage *image = self.image;
+    layer.contents = (__bridge id)image.CGImage;
 }
 
 @end


### PR DESCRIPTION
UIImageView does not response displayer in ios13

Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
