### PR TITLE
fix(ci): fix android build tests workflow throw `gradle not found` error

### DIFF
--- a/.github/workflows/android_build_tests.yml
+++ b/.github/workflows/android_build_tests.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Debug Build
       working-directory: ./examples/android-demo
       run: |
-        gradle assembleDebug
+        ./gradlew assembleDebug
     - name: Release Build
       working-directory: ./examples/android-demo
       run: |
-        gradle assembleRelease
+        ./gradlew assembleRelease


### PR DESCRIPTION
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [x] Squash the repeat code commits, short patches are welcome.
