### PR TITLE
fix(workflows): add accessible permission to avoid error

### DIFF
--- a/.github/workflows/gh_pr_labeler.yml
+++ b/.github/workflows/gh_pr_labeler.yml
@@ -1,7 +1,7 @@
 name: '[gh] pull request labeler'
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - main


### PR DESCRIPTION
add accessible permission to avoid
`Resource not accessible by integration` error

- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [x] Squash the repeat code commits, short patches are welcome.
