### PR TITLE
feat(android): change one byte string encoding

### DIFF
--- a/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/PrimitiveValueSerializer.java
+++ b/android/sdk/src/main/java/com/tencent/mtt/hippy/serialization/PrimitiveValueSerializer.java
@@ -58,6 +58,10 @@ public abstract class PrimitiveValueSerializer extends SharedSerialization {
    * Small string max length, used for SSO(Short / Small String Optimization).
    */
   private static final int SSO_SMALL_STRING_MAX_LENGTH = 32;
+  /**
+   * ISO-8859-1(Latin1) max char
+   */
+  private static final char ISO_8859_1_MAX_CHAR = 0xff;
 
   protected PrimitiveValueSerializer(BinaryWriter writer) {
     super();
@@ -308,11 +312,11 @@ public abstract class PrimitiveValueSerializer extends SharedSerialization {
     // Designed to take advantage of
     // https://wiki.openjdk.java.net/display/HotSpot/RangeCheckElimination
     if (length > SSO_SMALL_STRING_MAX_LENGTH) {
-      for (char c; i < length && (c = stringWriteBuffer[i]) < 0x80; i++) {
+      for (char c; i < length && (c = stringWriteBuffer[i]) <= ISO_8859_1_MAX_CHAR; i++) {
         writer.putByte((byte) c);
       }
     } else {
-      for (char c; i < length && (c = value.charAt(i)) < 0x80; i++) {
+      for (char c; i < length && (c = value.charAt(i)) <= ISO_8859_1_MAX_CHAR; i++) {
         writer.putByte((byte) c);
       }
     }
@@ -324,7 +328,7 @@ public abstract class PrimitiveValueSerializer extends SharedSerialization {
 
     // region two byte string, universal path
     writeTag(SerializationTag.TWO_BYTE_STRING);
-    writer.putVarint(length * 2);
+    writer.putVarint(length * 2L);
     if (length > SSO_SMALL_STRING_MAX_LENGTH) {
       for (i = 0; i < length; i++) {
         char c = stringWriteBuffer[i];


### PR DESCRIPTION
switch one byte string encoding
from ascii to latin1
during the serialization

Before submitting a new pull request, please make sure:

- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [x] Squash the repeat code commits, short patches are welcome.
