### PR TITLE
fix(ios): fix hippy view reuse bug

### DIFF
--- a/ios/sdk/module/uimanager/HippyUIManager.mm
+++ b/ios/sdk/module/uimanager/HippyUIManager.mm
@@ -1511,6 +1511,7 @@ static UIView *_jsResponder;
                 [container insertHippySubview:subview atIndex:index];
                 index++;
             }
+            [container clearSortedSubviews];
             [container didUpdateHippySubviews];
         }];
 


### PR DESCRIPTION
a hippy view creates its hierarchy by using sorted views.
so we must clear its previous sorted views, then sort its subviews

# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
