### PR TITLE
fix(ios): fix refresh component delay reset bug

### DIFF
--- a/renderer/native/ios/renderer/component/refresh/HippyRefresh.mm
+++ b/renderer/native/ios/renderer/component/refresh/HippyRefresh.mm
@@ -62,12 +62,15 @@
     [self refreshFinishWithOption:@{@"time": @(2000)}];
 }
 
+- (void)setRefreshStatusToIdle {
+    self.status = HippyRefreshStatusIdle;
+}
+
 - (void)refreshFinishWithOption:(NSDictionary *)options {
     self.status = HippyRefreshStatusFinishLoading;
     CGFloat time = [options[@"time"] doubleValue] / 1000.f;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(time * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        self.status = HippyRefreshStatusIdle;
-    });
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(setRefreshStatusToIdle) object:nil];
+    [self performSelector:@selector(setRefreshStatusToIdle) withObject:nil afterDelay:time];
 }
 
 @end


### PR DESCRIPTION
need to reset timer when new timer invoked

# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
