### PR TITLE
fix(ios): fix undo crash for uitextfiled component

### DIFF
--- a/renderer/native/ios/renderer/component/textinput/HippyTextField.mm
+++ b/renderer/native/ios/renderer/component/textinput/HippyTextField.mm
@@ -414,7 +414,14 @@ HIPPY_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
         }
         _onKeyPress(@{ @"key": resultKey });
     }
-    NSString *toBeString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    //https://stackoverflow.com/questions/55379602/ios-out-of-range-crash-when-using-shake-to-undo-a-paste-into-uitextview-with-ove?answertab=trending#tab-top
+    //Follows the above steps, [NSString stringByReplacingCharactersInRange:withString:] crashes
+    NSString *text = textField.text;
+    BOOL rangeSafeForText = (range.location != NSNotFound && range.location + range.length <= text.length);
+    if (!rangeSafeForText) {
+        return NO;
+    }
+    NSString *toBeString = [text stringByReplacingCharactersInRange:range withString:string];
     if (textField.isSecureTextEntry) {
         textField.text = toBeString;
         return NO;


### PR DESCRIPTION
# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
