### PR TITLE
fix(ios): hippy-vue textInput isFocused not working

### DIFF
--- a/ios/sdk/component/textinput/HippyTextField.m
+++ b/ios/sdk/component/textinput/HippyTextField.m
@@ -297,6 +297,10 @@ HIPPY_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     return [_textView becomeFirstResponder];
 }
 
+- (BOOL)isFirstResponder {
+    return [_textView isFirstResponder];
+}
+
 - (void)textview_becomeFirstResponder {
     if (_onFocus) {
         _onFocus(@{});


### PR DESCRIPTION
# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
