### PR TITLE
perf(ios): use respondsToSelector instead of conformsToProtocol

### DIFF
--- a/ios/sdk/module/uimanager/HippyUIManager.mm
+++ b/ios/sdk/module/uimanager/HippyUIManager.mm
@@ -115,22 +115,28 @@ HIPPY_EXPORT_MODULE()
 
 - (void)didReceiveMemoryWarning {
     for (UIView *view in [self->_viewRegistry allValues]) {
-        if ([view conformsToProtocol:@protocol(HippyMemoryOpt)]) {
-            [(id<HippyMemoryOpt>)view didReceiveMemoryWarning];
+//        if ([view conformsToProtocol:@protocol(HippyMemoryOpt)]) {
+//            [(id<HippyMemoryOpt>)view didReceiveMemoryWarning];
+//        }
+        //https://github.com/apple-oss-distributions/objc4/blob/8701d5672d3fd3cd817aeb84db1077aafe1a1604/runtime/objc-runtime-new.mm#L7108
+        //[NSObject conformsToProtocol:] uses a global mutex_t runtimeLock to lock, which may case lag in main thread
+        if ([view respondsToSelector:@selector(didReceiveMemoryWarning)]) {
+            [view performSelector:@selector(didReceiveMemoryWarning)];
         }
     }
 }
+
 - (void)appDidEnterBackground {
     for (UIView *view in [self->_viewRegistry allValues]) {
-        if ([view conformsToProtocol:@protocol(HippyMemoryOpt)]) {
-            [(id<HippyMemoryOpt>)view appDidEnterBackground];
+        if ([view respondsToSelector:@selector(appDidEnterBackground)]) {
+            [view performSelector:@selector(appDidEnterBackground)];
         }
     }
 }
 - (void)appWillEnterForeground {
     for (UIView *view in [self->_viewRegistry allValues]) {
-        if ([view conformsToProtocol:@protocol(HippyMemoryOpt)]) {
-            [(id<HippyMemoryOpt>)view appWillEnterForeground];
+        if ([view respondsToSelector:@selector(appWillEnterForeground)]) {
+            [view performSelector:@selector(appWillEnterForeground)];
         }
     }
 }


### PR DESCRIPTION
[NSObject conformsToProtocol:] ses a global mutex_t runtimeLock to lock, which may case lag in main thread

# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
