### PR TITLE
ci(workflows): replaced obsolete workflow command

### DIFF
--- a/.github/workflows/3rd_prebuilt_v8.yml
+++ b/.github/workflows/3rd_prebuilt_v8.yml
@@ -234,7 +234,7 @@ jobs:
       id: release_package
       working-directory: ./v8
       run: |
-        echo "::set-output name=head_full::$(git rev-parse HEAD)"
+        echo "head_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd out
         tar -zcvf android-${{ matrix.arch }}.tgz -C artifact .
     - name: Install Requirement
@@ -298,7 +298,7 @@ jobs:
       id: release_package
       working-directory: ./v8
       run: |
-        Write-Output "::set-output name=head_full::$(git rev-parse HEAD)"
+        Write-Output "head_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd out
         Compress-Archive -Path artifact\* -DestinationPath windows-${{ matrix.arch }}.zip
     - name: Install Requirement
@@ -359,7 +359,7 @@ jobs:
       id: release_package
       working-directory: ./v8
       run: |
-        echo "::set-output name=head_full::$(git rev-parse HEAD)"
+        echo "head_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd out
         tar -zcvf macos-${{ matrix.arch }}.tgz -C artifact .
     - name: Install Requirement
@@ -421,7 +421,7 @@ jobs:
       id: release_package
       working-directory: ./v8
       run: |
-        echo "::set-output name=head_full::$(git rev-parse HEAD)"
+        echo "head_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd out
         tar -zcvf linux-${{ matrix.arch }}.tgz -C artifact .
     - name: Install Requirement
@@ -493,7 +493,7 @@ jobs:
       id: release_package
       working-directory: ./v8
       run: |
-        echo "::set-output name=head_full::$(git rev-parse HEAD)"
+        echo "head_full=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         cd out
         tar -zcvf ios-${{ matrix.arch }}.tgz -C artifact .
     - name: Install Requirement

--- a/.github/workflows/docker_build_image.yml
+++ b/.github/workflows/docker_build_image.yml
@@ -26,10 +26,12 @@ jobs:
     steps:
       - name: Get changed images
         id: changed_images
-        uses: actions/github-script@v6.1.0
+        uses: actions/github-script@v6.3.3
         with:
           script: |
             const { basename, sep } = require('path');
+            const { appendFileSync } = require('fs');
+            const { EOL } = require('os');
             const { eventName } = context;
             const { owner, repo } = context.repo;
             const { repos } = github.rest;
@@ -66,7 +68,8 @@ jobs:
               }
             }
 
-            console.log(`::set-output name=changed_images::${JSON.stringify(Array.from(changedImages))}`);
+            appendFileSync(process.env.GITHUB_OUTPUT, `changed_images=${JSON.stringify(Array.from(changedImages))}${EOL}`, { encoding: 'utf8' });
+
   build_images:
     needs: changed_images
     runs-on: ${{ github.repository == 'Tencent/Hippy' && fromJson('[''self-hosted'', ''linux'']') || 'ubuntu-latest' }}

--- a/.github/workflows/gh_issue_crash_report.yml
+++ b/.github/workflows/gh_issue_crash_report.yml
@@ -42,7 +42,7 @@ jobs:
       repository_owner: ${{ steps.triage-result.outputs.repository_owner }}
     steps:
     - name: Greetings
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         script: |
           const { owner, repo } = context.repo;
@@ -63,7 +63,7 @@ jobs:
     - run: npm install markdown-it
     - name: Triage
       id: triage-result
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       env:
         issue_body: ${{ github.event.issue.body }}
       with:
@@ -71,6 +71,7 @@ jobs:
           const MarkdownIt = require('markdown-it');
           const os = require('os');
           const path = require('path');
+          const fs = require('fs');
 
           function parse(markdown) {
             const tokens = (new MarkdownIt()).parse(markdown, {});
@@ -115,11 +116,11 @@ jobs:
                 value = value.replaceAll(/[^0-9a-z\-_\.]/ig, '');
               }
               value = value.replaceAll('%', '%25').replaceAll('\n', '%0A').replaceAll('\r', '%0D');
-              console.log(`::set-output name=${key.toLowerCase()}::${value}`);
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key.toLowerCase()}=${value}${os.EOL}`, { encoding: 'utf8' });
             }
           });
 
-          console.log(`::set-output name=repository_owner::${'${{ github.repository_owner }}'.toLowerCase()}`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `repository_owner=${'${{ github.repository_owner }}'.toLowerCase()}${os.EOL}`, { encoding: 'utf8' });
 
   android-translates-addresses:
     needs:
@@ -144,7 +145,7 @@ jobs:
         app-id: ${{ secrets.BOT_APP_ID }}
     - name: Backtrace
       id: backtrace_parsed
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       env:
         triage_logs: ${{ needs.triage.outputs.logs }}
       with:
@@ -152,6 +153,8 @@ jobs:
         script: |
           const { owner, repo } = context.repo;
           const { issues } = github.rest;
+          const { appendFileSync } = require('fs');
+          const { EOL } = require('os');
 
           function parse(log) {
             const stack = [];
@@ -163,7 +166,7 @@ jobs:
 
           const backtrace = parse(process.env.triage_logs);
           if (backtrace.length > 0) {
-            console.log(`::set-output name=backtrace::${JSON.stringify(backtrace)}`);
+            appendFileSync(process.env.GITHUB_OUTPUT, `backtrace=${JSON.stringify(backtrace)}${EOL}`, { encoding: 'utf8' });
           }
 
           await issues.createComment({
@@ -194,8 +197,8 @@ jobs:
         mkdir symbols
         unzip -d symbols $ZIP_FILE
         rm $ZIP_FILE
-        echo "::set-output name=success::1"
-    - uses: actions/github-script@v6.1.0
+        echo "success=1" >> $GITHUB_OUTPUT
+    - uses: actions/github-script@v6.3.3
       if: ${{ !steps.symbols_fetched.outputs.success }}
       with:
         github-token: ${{ steps.get-token.outputs.token }}
@@ -212,7 +215,7 @@ jobs:
           });
     - name: Translates
       if: steps.symbols_fetched.outputs.success
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         github-token: ${{ steps.get-token.outputs.token }}
         script: |

--- a/.github/workflows/gh_pr_checks_approval.yml
+++ b/.github/workflows/gh_pr_checks_approval.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - name: Greetings
       if: github.event.action == 'opened'
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         script: |
           const { owner, repo } = context.repo;
@@ -50,7 +50,7 @@ jobs:
         private-key: ${{ secrets.BOT_APP_KEY }}
         app-id: ${{ secrets.BOT_APP_ID }}
     - name: Checks
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         github-token: ${{ steps.get-token.outputs.token }}
         script: |

--- a/.github/workflows/hip_archive_artifact.yml
+++ b/.github/workflows/hip_archive_artifact.yml
@@ -57,7 +57,7 @@ jobs:
         git clone ${{ github.event.inputs.source_url }} artifact
         pushd artifact
         git checkout ${{ github.event.inputs.git_revision }}
-        echo "::set-output name=git-head::$(git rev-parse HEAD)"
+        echo "git-head=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         rm -rf .git
         popd
         tar -zcvf $name -C artifact .

--- a/.github/workflows/security_codeql_analyses.yml
+++ b/.github/workflows/security_codeql_analyses.yml
@@ -29,16 +29,18 @@ jobs:
     steps:
     - name: Detect Languages
       id: detect_languages
-      uses: actions/github-script@v6.1.0
+      uses: actions/github-script@v6.3.3
       with:
         script: |
           const { owner, repo } = context.repo;
           const { pull_request } = context.payload;
           const { pulls } = github.rest;
           const path = require('path');
+          const fs = require('fs');
+          const os = require('os');
 
           if (pull_request === undefined) { // Push
-            console.log("::set-output name=language::${{ matrix.language }}");
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `language=${{ matrix.language }}${os.EOL}`, { encoding: 'utf8' });
             return;
           }
 
@@ -52,6 +54,7 @@ jobs:
           const all_exts = Object.values(languages).flat();
           const cur_exts = languages["${{ matrix.language }}"];
 
+          let match_all = false;
           let has_hit = false;
 
           try {
@@ -64,27 +67,28 @@ jobs:
               for (const { filename } of files) {
                 const ext = path.extname(filename);
                 if (cur_exts.includes(ext)) {
-                  console.log("::set-output name=language::${{ matrix.language }}");
+                  has_hit = true;
                   done();
+                  break;
                 } else {
-                  has_hit |= all_exts.includes(ext);
+                  match_all |= all_exts.includes(ext);
                 }
               }
               return [files.length];
             })).reduce((a, b) => a + b, 0);
 
             if (count === 3_000) { // The paginated response include a maximum of 3000 files
-              console.log("::set-output name=language::${{ matrix.language }}"); // Fallback to all language
-              return;
+              has_hit = true;
             }
           } catch (e) {
             console.error(e);
-            console.log("::set-output name=language::${{ matrix.language }}"); // Fallback to all language
-            return;
+            has_hit = true;
           }
 
-          if (!has_hit && "${{ matrix.language }}" === "typescript") { // Default Run
-            console.log("::set-output name=default-run::1");
+          if (has_hit) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `language=${{ matrix.language }}${os.EOL}`, { encoding: 'utf8' });
+          } else if (!match_all && "${{ matrix.language }}" === "typescript") { // Default Run
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `default-run::1${os.EOL}`, { encoding: 'utf8' });
           }
     - name: Checkout
       if: steps.detect_languages.outputs.language


### PR DESCRIPTION
replaced obsolete workflow output command `set-output` with `GITHUB_OUTPUT` environment file.

# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
