### PR TITLE
feat(android): enable Safe ICF to optimize binary size

### DIFF
--- a/android/sdk/src/main/jni/CMakeLists.txt
+++ b/android/sdk/src/main/jni/CMakeLists.txt
@@ -45,6 +45,9 @@ if (${ANDROID_STL} STREQUAL "c++_static")
       "-Wl,--exclude-libs,libc++_static.a"
       "-Wl,--exclude-libs,libc++abi.a")
 endif ()
+# enable Safe ICF (Identical Code Folding) to optimize binary size
+target_link_options(${PROJECT_NAME} PRIVATE
+      "-Wl,--icf=safe")
 # endregion
 
 # region core

--- a/buildconfig/cmake/compiler_toolchain.cmake
+++ b/buildconfig/cmake/compiler_toolchain.cmake
@@ -47,6 +47,15 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # based on LLVM 12
       -Os)
 
   if (ANDROID_NDK)
+    # Android NDK default to -fno-addrsig
+    # in order to support linkers other than LLD [1],
+    # but we only uses LLD linker, so enable faddrsing to produce
+    # a special section `.llvm_addrsig` to support ICF (Identical Code Folding) [2].
+    #
+    # [1] https://reviews.llvm.org/D56456
+    # [2] https://github.com/android/ndk/issues/1670#issuecomment-1040941456
+    list(APPEND COMPILE_OPTIONS -faddrsig)
+
     if (${ANDROID_ABI} STREQUAL "armeabi-v7a")
       list(APPEND COMPILE_OPTIONS -mfloat-abi=softfp)
     elseif (${ANDROID_ABI} STREQUAL "arm64-v8a")


### PR DESCRIPTION
enable Safe ICF to optimize binary size,  reduced ~36k size
```
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_env.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/js2java.cc.o:(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/js2java.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/java_turbo_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/request_interrupt.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
selected section core/libcore.a(task_runner.cc.o):(.data.rel.ro)
  removing identical section core/libcore.a(javascript_task_runner.cc.o):(.data.rel.ro)
selected section core/libcore.a(task.cc.o):(.text)
  removing identical section core/libcore.a(thread.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
selected section core/libcore.a(task_runner.cc.o):(.text)
  removing identical section core/libcore.a(javascript_task_runner.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
selected section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_env.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/uri.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/jni/jni_utils.cc.o:(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/java_turbo_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.data.rel.ro)
selected section core/libcore.a(common_task.cc.o):(.text)
  removing identical section core/libcore.a(javascript_task.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(native_source_code_android.cc.o):(.text)
selected section core/libcore.a(js_value_wrapper.cc.o):(.text)
  removing identical section core/libcore.a(js_value_wrapper.cc.o):(.text)
  removing identical section core/libcore.a(js_value_wrapper.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/adr_bridge.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/js2java.cc.o:(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/adr_bridge.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/adr_bridge.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_env.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section core/libcore.a(task.cc.o):(.text)
  removing identical section core/libcore.a(thread.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
  removing identical section core/libcore.a(v8_channel_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.data.rel.ro)
selected section CMakeFiles/hippy.dir/src/bridge/adr_bridge.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/js2java.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/js2java.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_env.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_env.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.data.rel.ro)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.data.rel.ro)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/request_interrupt.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/turbo_module_manager.cc.o:(.text)
  removing identical section core/libcore.a(js_native_api_v8.cc.o):(.text)
  removing identical section core/libcore.a(native_source_code_android.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
  removing identical section core/libcore.a(v8_inspector_client_impl.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/performance/memory.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/java_turbo_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/runtime.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/interrupt_queue.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/timer_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/contextify_module.cc.o:(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_register.cc.o:(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section CMakeFiles/hippy.dir/src/jni/convert_utils.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/jni/jni_register.cc.o:(.text)
  removing identical section core/libcore.a(task_runner.cc.o):(.text)
selected section CMakeFiles/hippy.dir/D_/Hippy/core/src/modules/console_module.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/D_/Hippy/core/src/napi/v8/memory_module.cc.o:(.text)
selected section core/libcore.a(callback_info.cc.o):(.text)
  removing identical section core/libcore.a(callback_info.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/loader/adr_loader.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/v8/heap_limit.cc.o:(.text)
  removing identical section core/libcore.a(engine.cc.o):(.text)
  removing identical section core/libcore.a(scope.cc.o):(.text)
  removing identical section core/libcore.a(js_native_turbo_v8.cc.o):(.text)
selected section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
  removing identical section CMakeFiles/hippy.dir/src/bridge/entry.cc.o:(.text)
```


# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
