### PR TITLE
docs(fontWeight): update `fontWeight` style

### DIFF
--- a/docs/en-us/style/appearance.md
+++ b/docs/en-us/style/appearance.md
@@ -172,7 +172,7 @@ Font weight
 
 | Type               | Required| Supported Platforms
 | ------ | -------- | --- |
-| number \| string |No|  Android,iOS
+| string |No|  Android,iOS
 
 # letterSpacing
 

--- a/docs/style/appearance.md
+++ b/docs/style/appearance.md
@@ -172,7 +172,7 @@
 
 | 类型   | 必需 | 支持平台
 | ------ | -------- | --- |
-| number \| string | 否 | Android、iOS
+| string | 否 | Android、iOS
 
 # letterSpacing
 


### PR DESCRIPTION
# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.

**`Merge msg`**: In iOS, the type of `fontweight` does not support `Number`, only `String` is supported, and an error will be reported in the iOS simulator of the development environment