### PR TITLE
fix(ios): move module init from asynchronization to synchronization

### DIFF
--- a/framework/ios/base/bridge/HippyBridge.mm
+++ b/framework/ios/base/bridge/HippyBridge.mm
@@ -269,14 +269,16 @@ dispatch_queue_t HippyBridgeQueue() {
             _javaScriptExecutor.contextName = _contextName;
         }
         _displayLink = [[HippyDisplayLink alloc] init];
-        dispatch_async(HippyBridgeQueue(), ^{
+        //The caller may attempt to look up a module immediately after creating the HippyBridge,
+        //therefore the initialization of all modules cannot be placed in a sub-thread
+//        dispatch_async(HippyBridgeQueue(), ^{
             [self initWithModulesCompletion:^{
                 HippyBridge *strongSelf = weakSelf;
                 if (strongSelf) {
                     dispatch_semaphore_signal(strongSelf.moduleSemaphore);
                 }
             }];
-        });
+//        });
     } @catch (NSException *exception) {
         HippyBridgeHandleException(exception, self);
     }


### PR DESCRIPTION
The caller may attempt to look up a module immediately after creating the HippyBridge, therefore the initialization of all modules cannot be placed in a sub-thread

# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
