### PR TITLE
fix(ios): onChange event not triggered when typing Chinese Pinyin

### DIFF
--- a/ios/sdk/component/textinput/HippyTextField.m
+++ b/ios/sdk/component/textinput/HippyTextField.m
@@ -187,15 +187,6 @@ HIPPY_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 }
 
 - (void)textFieldDidChange {
-    UITextRange *selectedRange = [_textView markedTextRange];
-    NSString *newText = [_textView textInRange:selectedRange];
-    /**获取中文输入法下高亮部分并直接返回不做_onChangeText */
-    if (newText.length > 0) {
-        return;
-    }
-    // selectedTextRange observer isn't triggered when you type even though the
-    // cursor position moves, so we send event again here.
-
     if (!self.hippyTag || !_onChangeText) {
         return;
     }


### PR DESCRIPTION
# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
