### PR TITLE
feat(ios): optimize method loadImage:completed:

### DIFF
--- a/ios/sdk/component/image/HippyImageViewCustomLoader.h
+++ b/ios/sdk/component/image/HippyImageViewCustomLoader.h
@@ -40,12 +40,19 @@ typedef void(^HippyImageLoaderCompletionBlock)(NSData *_Nullable data,
                                                UIImage *_Nullable image,
                                                HippyImageCustomLoaderControlOptions options);
 
+typedef void(^HippyImageLoaderLoadURLCompletionBlock)(NSData *_Nullable data,
+                                               NSURL * _Nonnull url,
+                                               NSError *_Nullable error,
+                                               UIImage *_Nullable image,
+                                               BOOL cached);
 
 @protocol HippyImageViewCustomLoader <HippyBridgeModule>
 
 @optional
 
 - (BOOL)canHandleImageURL:(NSURL *)url;
+
++ (NSData *)convertImageToData:(UIImage *)image;
 
 @required
 
@@ -57,7 +64,7 @@ typedef void(^HippyImageLoaderCompletionBlock)(NSData *_Nullable data,
 
 - (void)cancelImageDownload:(UIImageView *)imageView withUrl:(NSURL *)url;
 
-- (void)loadImage:(NSURL *)url completed:(void (^)(NSData *, NSURL *, NSError *, BOOL cached))completedBlock;
+- (void)loadImage:(NSURL *)url completed:(HippyImageLoaderLoadURLCompletionBlock)completedBlock;
 
 @end
 

--- a/ios/sdk/component/view/HippyBackgroundImageCacheManager.m
+++ b/ios/sdk/component/view/HippyBackgroundImageCacheManager.m
@@ -80,9 +80,9 @@
     }
     id<HippyImageViewCustomLoader> imageLoader = self.bridge.imageLoader;
     if (imageLoader) {
-        [imageLoader loadImage:imageURL completed:^(NSData *imgData, NSURL *url, NSError *error, BOOL cached) {
-            UIImage *image = [UIImage imageWithData:imgData scale:[UIScreen mainScreen].scale];
-            completionHandler(image, error);
+        [imageLoader loadImage:imageURL completed:^(NSData *imgData, NSURL *url, NSError *error, UIImage *image, BOOL cached) {
+            UIImage *img = image ?: [UIImage imageWithData:imgData scale:[UIScreen mainScreen].scale];
+            completionHandler(img, error);
         }];
     } else {
         if ([uri hasPrefix:@"http://"] || [uri hasPrefix:@"https://"]) {


### PR DESCRIPTION
In the protocol of HippyImageViewCustomLoader, there is a method called loadImage:completed:. As an iOS developer, we usually use SDWebImage to implement this interface. The loadImage(_:completed:) method is implemented using the loadImage(with:options:progress:completed:) method provided by SDWebImageManager.

     [SDWebImageManager.sharedManager loadImageWithURL:url options:0 progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) { completedBlock(data, url, error,  !!cacheType); }];

However, this implementation encountered some exceptions in practical scenarios. When the loaded image is found in the memory cache, the image parameter in the callback of the SDWebImageManager method has a value, but the data parameter is empty. This causes the image to fail to load in the application.

Therefore, aligning the interface with SDWebImage and internally handling this scenario will make it more convenient for integrators to implement and avoid encountering the same issue as I did.