### PR TITLE
minify bundle size

### DIFF
--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.android-vendor.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.android-vendor.js
@@ -18,7 +18,6 @@ module.exports = {
     library: 'hippyReactBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.android.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.android.js
@@ -22,7 +22,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyReactDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.ios-vendor.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.ios-vendor.js
@@ -18,7 +18,6 @@ module.exports = {
     library: 'hippyReactBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.ios.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.ios.js
@@ -22,7 +22,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyReactDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web-renderer.dev.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web-renderer.dev.js
@@ -29,7 +29,6 @@ module.exports = {
     globalObject: '(0, eval)("this")',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new HtmlWebpackPlugin({
       inject: true,
       scriptLoading: 'blocking',

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web-renderer.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web-renderer.js
@@ -17,7 +17,6 @@ module.exports = {
     path: path.resolve(`./dist/${platform}/`),
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web.dev.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web.dev.js
@@ -25,7 +25,6 @@ module.exports = {
     path: path.resolve(`./dist/${platform}/`),
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('development'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web.js
+++ b/driver/js/examples/hippy-react-demo/scripts/hippy-webpack.web.js
@@ -18,7 +18,6 @@ module.exports = {
     path: path.resolve(`./dist/${platform}/`),
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.android-vendor.js
+++ b/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.android-vendor.js
@@ -31,7 +31,6 @@ module.exports = {
     library: 'hippyVueBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.android.js
+++ b/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.android.js
@@ -43,7 +43,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyVueDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.ios-vendor.js
+++ b/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.ios-vendor.js
@@ -31,7 +31,6 @@ module.exports = {
     library: 'hippyVueBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.ios.js
+++ b/driver/js/examples/hippy-vue-demo/scripts/hippy-webpack.ios.js
@@ -43,7 +43,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyVueDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.android-vendor.js
+++ b/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.android-vendor.js
@@ -19,7 +19,6 @@ module.exports = {
     library: 'hippyVueBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.android.js
+++ b/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.android.js
@@ -31,7 +31,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyVueNextDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.ios-vendor.js
+++ b/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.ios-vendor.js
@@ -19,7 +19,6 @@ module.exports = {
     library: 'hippyVueBase',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.ios.js
+++ b/driver/js/examples/hippy-vue-next-demo/scripts/hippy-webpack.ios.js
@@ -31,7 +31,6 @@ module.exports = {
     // publicPath: 'https://xxx/hippy/hippyVueNextDemo/',
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
       __PLATFORM__: JSON.stringify(platform),

--- a/driver/js/package-lock.json
+++ b/driver/js/package-lock.json
@@ -57,7 +57,7 @@
         "trim-newlines": "^3.0.1",
         "ts-jest": "^27.1.2",
         "tslib": "^2.3.1",
-        "ttypescript": "^1.5.13",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.8.3",
         "typescript-transform-paths": "^3.3.1",
         "vue": "^2.6.14",
@@ -20540,9 +20540,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://mirrors.tencent.com/npm/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"

--- a/driver/js/package.json
+++ b/driver/js/package.json
@@ -73,7 +73,7 @@
     "trim-newlines": "^3.0.1",
     "ts-jest": "^27.1.2",
     "tslib": "^2.3.1",
-    "ttypescript": "^1.5.13",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.8.3",
     "typescript-transform-paths": "^3.3.1",
     "vue": "^2.6.14",

--- a/driver/js/packages/hippy-vue-css-loader/src/css-loader.ts
+++ b/driver/js/packages/hippy-vue-css-loader/src/css-loader.ts
@@ -38,11 +38,10 @@ function hippyVueCSSLoader(this: any, source: any) {
   const hash = crypto.createHash(hashType);
   const contentHash = hash.update(source).digest('hex');
   sourceId += 1;
-  const rulesAst = parsed.stylesheet.rules.filter((n: any) => n.type === 'rule').map((n: any) => ({
-    hash: contentHash,
-    selectors: n.selectors,
-
-    declarations: n.declarations.map((dec: any) => {
+  const rulesAst = parsed.stylesheet.rules.filter(n => n.type === 'rule').map(n => ([
+    contentHash,
+    n.selectors,
+    n.declarations.filter(dec => dec.type !== 'comment').map((dec) => {
       let { value } = dec;
       const isVariableColor = dec.property?.startsWith('-') && typeof value === 'string'
         && (
@@ -55,13 +54,9 @@ function hippyVueCSSLoader(this: any, source: any) {
       if (dec.property && (dec.property.toLowerCase().indexOf('color') > -1 || isVariableColor)) {
         value = translateColor(value);
       }
-      return {
-        type: dec.type,
-        property: dec.property,
-        value,
-      };
+      return [dec.property, value];
     }),
-  }));
+  ])).filter(rule => rule[2].length > 0);
   const code = `(function(n) {
     if (!global[n]) {
       global[n] = [];

--- a/driver/js/packages/hippy-vue-css-loader/src/css-loader.ts
+++ b/driver/js/packages/hippy-vue-css-loader/src/css-loader.ts
@@ -62,11 +62,11 @@ function hippyVueCSSLoader(this: any, source: any) {
       };
     }),
   }));
-  const code = `(function() {
-    if (!global['${GLOBAL_STYLE_NAME}']) {
-      global['${GLOBAL_STYLE_NAME}'] = [];
+  const code = `(function(n) {
+    if (!global[n]) {
+      global[n] = [];
     }
-    global['${GLOBAL_STYLE_NAME}'] = global['${GLOBAL_STYLE_NAME}'].concat(${JSON.stringify(rulesAst)});
+    global[n] = global[n].concat(${JSON.stringify(rulesAst)});
 
     if(module.hot) {
       module.hot.dispose(() => {
@@ -77,7 +77,7 @@ function hippyVueCSSLoader(this: any, source: any) {
         global['${GLOBAL_DISPOSE_STYLE_NAME}'] = global['${GLOBAL_DISPOSE_STYLE_NAME}'].concat('${contentHash}');
       })
     }
-  })()`;
+  })('${GLOBAL_STYLE_NAME}')`;
   return `module.exports=${code}`;
 }
 

--- a/driver/js/packages/hippy-vue-next/__test__/runtime/style/index.test.ts
+++ b/driver/js/packages/hippy-vue-next/__test__/runtime/style/index.test.ts
@@ -24,7 +24,7 @@
  */
 import { HIPPY_GLOBAL_DISPOSE_STYLE_NAME, HIPPY_GLOBAL_STYLE_NAME } from '../../../src/config';
 import { HippyElement } from '../../../src/runtime/element/hippy-element';
-import { fromAstNodes, SelectorsMap } from '../../../src/runtime/style';
+import { fromAstNodes, SelectorsMap, type ASTRule } from '../../../src/runtime/style';
 import { SimpleSelectorSequence } from '../../../src/runtime/style/css-selectors';
 import { getCssMap } from '../../../src/runtime/style/css-map';
 import { registerElement } from '../../../src/runtime/component';
@@ -243,6 +243,16 @@ const testAst = [
   },
 ];
 
+type ASTItem = typeof testAst[1];
+
+function minifyAst(rules: ASTItem[]): ASTRule[] {
+  return rules.map(r => ([
+    r.hash,
+    r.selectors,
+    r.declarations.filter(d => d.type !== 'comment').map(d => ([d.property, d.value])),
+  ] as ASTRule)).filter(r => r[2].length > 0);
+}
+
 /**
  * @author birdguo
  * @priority P0
@@ -252,7 +262,7 @@ describe('runtime/style/index.ts', () => {
   let cssMap;
 
   beforeAll(() => {
-    global[HIPPY_GLOBAL_STYLE_NAME] = testAst;
+    global[HIPPY_GLOBAL_STYLE_NAME] = minifyAst(testAst);
     cssMap = getCssMap();
     registerElement('div', { component: { name: 'View' } });
     const root = new HippyElement('div');
@@ -326,7 +336,7 @@ describe('runtime/style/index.ts', () => {
       },
     ];
 
-    const appendRules = fromAstNodes(appendAst);
+    const appendRules = fromAstNodes(minifyAst(appendAst));
     cssMap.append(appendRules);
 
     const divElement = new HippyElement('div');
@@ -365,7 +375,7 @@ describe('runtime/style/index.ts', () => {
       },
     ];
 
-    const appendRules = fromAstNodes(appendAst);
+    const appendRules = fromAstNodes(minifyAst(appendAst));
     cssMap.append(appendRules);
 
     const divElement = new HippyElement('div');
@@ -411,7 +421,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id1');
@@ -442,7 +452,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id');
@@ -470,7 +480,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id');
@@ -498,7 +508,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id');
@@ -526,7 +536,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id');
@@ -554,7 +564,7 @@ describe('runtime/style/index.ts', () => {
       ],
     }];
 
-    const cssRules = fromAstNodes(ast);
+    const cssRules = fromAstNodes(minifyAst(ast));
     const cssMap = new SelectorsMap(cssRules);
     const divElement = new HippyElement('div');
     divElement.setAttribute('id', 'id');

--- a/driver/js/packages/hippy-vue-next/src/runtime/style/css-selectors.ts
+++ b/driver/js/packages/hippy-vue-next/src/runtime/style/css-selectors.ts
@@ -805,4 +805,5 @@ export {
   Selector,
   RuleSet,
   SelectorCore,
+  type RuleSetSelector,
 };

--- a/driver/js/packages/hippy-vue/src/renderer/native/style/__tests__/helper.js
+++ b/driver/js/packages/hippy-vue/src/renderer/native/style/__tests__/helper.js
@@ -1,0 +1,7 @@
+export function minifyAst(rules) {
+  return rules.map(r => ([
+    r.hash,
+    r.selectors,
+    r.declarations.filter(d => d.type !== 'comment').map(d => ([d.property, d.value])),
+  ])).filter(r => r[2].length > 0);
+}

--- a/driver/js/packages/hippy-vue/src/style/ruleset.ts
+++ b/driver/js/packages/hippy-vue/src/style/ruleset.ts
@@ -32,7 +32,7 @@ export interface CssDeclarationType {
   value: string | number;
 }
 
-type RuleSetSelector = SelectorCore & { ruleSet: RuleSet };
+export type RuleSetSelector = SelectorCore & { ruleSet: RuleSet };
 
 /**
  * Rule Set


### PR DESCRIPTION
以 hippy-vue-next-demo index.android.js 为例，优化前 328KB， 优化后 302 KB。项目越大效果越明显。

优化点：
1. 优化 hippy-vue-css-loader 生成代码体积。具体为将 __HIPPY_VUE_STYLES__ 字符串抽取变量，减少重复。
2. 去掉 webpack 配置中的 webpack.NamedModulesPlugin , 此 Plugin  以废弃且生成的代码中会携带源码路径信息。

优化前生成代码
![origin](https://github.com/Tencent/Hippy/assets/24869428/cc22cead-e7f0-4cb2-8dee-76eee4c6566a)
优化后生成代码
![new](https://github.com/Tencent/Hippy/assets/24869428/15104313-84ce-4c8c-980f-82d59447590d)
