### PR TITLE
fix(ios): prevent crashes due to nan values when doing hippySetFrame

### DIFF
--- a/renderer/native/ios/renderer/component/view/UIView+Hippy.mm
+++ b/renderer/native/ios/renderer/component/view/UIView+Hippy.mm
@@ -280,6 +280,13 @@ HippyEventMethod(OnTouchEnd, onTouchEnd, OnTouchEventHandler)
 }
 
 - (void)hippySetFrame:(CGRect)frame {
+    // Avoid crashes due to NaN values
+    if (isnan(frame.origin.x) || isnan(frame.origin.y) ||
+        isnan(frame.size.width) || isnan(frame.size.height)) {
+        HippyLogError(@"Invalid layout for (%@)%@. frame: %@", self.hippyTag, self, NSStringFromCGRect(frame));
+        return;
+    }
+    
     self.frame = frame;
 }
 


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
