### PR TITLE
build(ios): fix no std:function build error on Xcode15.3

### DIFF
--- a/core/third_party/base/include/base/logging.h
+++ b/core/third_party/base/include/base/logging.h
@@ -25,6 +25,7 @@
 #include <codecvt>
 #include <sstream>
 #include <mutex>
+#include <functional>
 
 #include "log_level.h"
 #include "macros.h"

--- a/core/third_party/base/src/platform/ios/logging.cc
+++ b/core/third_party/base/src/platform/ios/logging.cc
@@ -3,7 +3,6 @@
 #include "base/logging.h"
 
 #include <syslog.h>
-
 #include <algorithm>
 #include <iostream>
 


### PR DESCRIPTION
# Pre-PR Checklist

- [x] I added/updated relevant documentation.
- [x] I followed the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters to submit commit message.
- [x] I squashed the repeated code commits.
- [x] I signed the [CLA].
- [x] I added/updated test cases to check the change I am making.
- [x] All existing and new tests are passing.
