### PR TITLE
fix(ios): listview endReached not working when preloadItemNumber is 0

### DIFF
--- a/renderer/native/ios/renderer/component/listview/HippyNextBaseListView.mm
+++ b/renderer/native/ios/renderer/component/listview/HippyNextBaseListView.mm
@@ -54,7 +54,6 @@ static NSString *const kListViewItem = @"ListViewItem";
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
         _isInitialListReady = NO;
-        self.preloadItemNumber = 1;
     }
     return self;
 }
@@ -254,7 +253,8 @@ referenceSizeForHeaderInSection:(NSInteger)section {
     }
     if (self.onEndReached) {
         NSInteger lastSectionIndex = [self numberOfSectionsInCollectionView:collectionView] - 1;
-        NSInteger lastRowIndexInSection = [self collectionView:collectionView numberOfItemsInSection:lastSectionIndex] - self.preloadItemNumber;
+        NSInteger itemsCount = [self collectionView:collectionView numberOfItemsInSection:lastSectionIndex];
+        NSInteger lastRowIndexInSection = itemsCount -1 - self.preloadItemNumber;
         if (lastRowIndexInSection < 0) {
             lastRowIndexInSection = 0;
         }


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
