### PR TITLE
fix(ios): Remove HippyContext prefix. It has been set outside

### DIFF
--- a/framework/ios/base/executors/HippyJSExecutor.mm
+++ b/framework/ios/base/executors/HippyJSExecutor.mm
@@ -550,8 +550,7 @@ static void setupDebuggerAgent(HippyBridge *bridge, const std::shared_ptr<hippy:
         }
         auto tryCatch = hippy::TryCatch::CreateTryCatchScope(true, context);
         auto jsc_context = std::static_pointer_cast<hippy::napi::JSCCtx>(context);
-        NSString *finalName = [NSString stringWithFormat:@"HippyContext: %@", contextName];
-        jsc_context->SetName((__bridge CFStringRef)finalName);
+        jsc_context->SetName((__bridge CFStringRef)contextName);
         if (tryCatch->HasCaught()) {
             HippyLogWarn(@"set context throw exception");
         }


### PR DESCRIPTION
Remove HippyContext prefix in `- (void)setContextName:(NSString *)contextName`. It has been set by outside, so it's redundant to add again. 

```ts
export function hippyRegister(appName, entryFunc) {
  // Call the iOS native for rename the context to appName.
  if (__HIPPYNATIVEGLOBAL__.OS === 'ios') {
    Hippy.bridge.callNative('JSCExecutor', 'setContextName', `HippyContext: ${appName}`);  // here
  }
  __GLOBAL__.appRegister[appName] = {
    run: entryFunc,
  };
}
```

<img width="518" alt="image" src="https://github.com/user-attachments/assets/bd63b62e-c82a-4010-b0a4-d25ad799220e" />

I do see a few places trying to assemble contextName in `HippyDevInfo` and `efault_runtime_notification`, it seems scattered. 
Please review and suggest whether we should add the in setContext or outside and advice what's the correct thing regarding the prefix.

IMO it would be caller's choice to do so unless you have magic words to make something work.
