### PR TITLE
fix(ohos): fix ImageView capInsets prop type crash

### DIFF
--- a/framework/ohos/src/main/cpp/impl/renderer/native/src/components/image_view.cc
+++ b/framework/ohos/src/main/cpp/impl/renderer/native/src/components/image_view.cc
@@ -115,7 +115,7 @@ bool ImageView::SetPropImpl(const std::string &propKey, const HippyValue &propVa
     return true;
   } else if (propKey == "capInsets") {
     HippyValueObjectType m;
-    if (propValue.ToObject(m)) {
+    if (propValue.IsObject() && propValue.ToObject(m)) {
       auto left = HRValueUtils::GetFloat(m["left"]);
       auto top = HRValueUtils::GetFloat(m["top"]);
       auto right = HRValueUtils::GetFloat(m["right"]);


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated/passed for the code you will submit.
- [ ] Documentation has added or updated.
- [ ] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline with maximum 72 characters.
- [ ] Squash the repeat code commits, short patches are welcome.
