### PR TITLE
fix(android): fix swipe component scroll animation abnormal on certain items

### DIFF
--- a/renderer/native/android/src/main/java/com/tencent/mtt/supportui/views/viewpager/ViewPager.java
+++ b/renderer/native/android/src/main/java/com/tencent/mtt/supportui/views/viewpager/ViewPager.java
@@ -1261,7 +1261,9 @@ public class ViewPager extends ViewGroup implements ScrollChecker.IScrollCheck
 				{// 默认修改大小，如果以后有新的属性需要增加返回类型
 					ii.sizeFactor = mAdapter.getPageSize(ii.position);
 					needPopulate = true;
-				}
+				} else {
+                    needPopulate = false;
+                }
 			}
 
 			if (newPos == ViewPagerAdapter.POSITION_UNCHANGED)


### PR DESCRIPTION
When swiping the second and second-to-last items left or right, even if the element content doesn't change, a layout reset will still be triggered, causing the swiping animation to fail.