### PR TITLE
docs: fix typos in PUBLISH.md

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -4,7 +4,7 @@ Hippy version management follows principle that all modules use same version.
 
 ## 1. Update Version Number
 
-The front-end Uses [lerna](https://lerna.js.org/) for versioning and CHANGELOG generation, but cannot use its publishing functionality because it needs to update the terminal package.
+The front-end uses [lerna](https://lerna.js.org/) for versioning and CHANGELOG generation, but cannot use its publishing functionality because it needs to update the terminal package.
 
 Update version and CHANGELOG usage:
 
@@ -155,7 +155,7 @@ git push origin tag          # 提交 tag
     ```bash
       // annotation local reference in `setting.gradle` 
       // include 'android-sdk'
-      // project(':android-sdk').projectDir = new File('../../ android/sdk')
+      // project(':android-sdk').projectDir = new File('../../android/sdk')
 
       --------------
 


### PR DESCRIPTION
Fixed two small typos in the publishing documentation:
- Corrected capitalization: 'Uses' to 'uses' on line 7
- Removed extra space in file path on line 158