### PR TITLE
fix(android): use equals() instead of == for string comparison in Deserializer

### DIFF
--- a/framework/android/src/main/java/com/tencent/mtt/hippy/serialization/compatible/Deserializer.java
+++ b/framework/android/src/main/java/com/tencent/mtt/hippy/serialization/compatible/Deserializer.java
@@ -239,7 +239,7 @@ public class Deserializer extends PrimitiveValueDeserializer {
         if (key instanceof Number) {
           object.pushObject(String.valueOf(key), value);
         } else if (key instanceof String) {
-          if (key == "null") {
+          if ("null".equals(key)) {
             object.pushObject(null, value);
           } else {
             object.pushObject((String) key, value);
@@ -263,7 +263,7 @@ public class Deserializer extends PrimitiveValueDeserializer {
       key = key.toString();
       Object value = readValue(StringLocation.MAP_VALUE, key);
       if (value != Undefined) {
-        if (key == "null") {
+        if ("null".equals(key)) {
           object.pushObject(null, value);
         } else {
           object.pushObject((String) key, value);


### PR DESCRIPTION
## Summary
- Fix `key == "null"` to `"null".equals(key)` in `Deserializer.java` (lines 242, 266)
- The `==` operator checks reference equality, not value equality
- When strings are deserialized from binary format, they are not interned, so `==` comparison with the literal `"null"` would always fail
- This bug causes the `null` key handling logic to never trigger, potentially leading to incorrect map deserialization

## Test plan
- [ ] Verify that deserializing a map with a `"null"` string key correctly pushes a null key to the HippyMap/HippyArray
- [ ] Run existing serialization/deserialization unit tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)